### PR TITLE
Make repos list use GitHub API

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
       <p class="headline">
         A list of active
         <a href="https://hackclub.com/">Hack Club</a>
-        open source repositories with available issues on
+        open source repositories on
         <a href="https://github.com/">GitHub</a>
       </p>
     </header>
@@ -62,10 +62,10 @@
 
     <div class="repos" data-tag="repos">
       <div class="container">
-        <h2 class="title">Active repositories with open issues</h2>
+        <h2 class="title">Active repositories</h2>
         <div class="no-repos lead hidden" data-tag="no-repos">
-          Wow, it looks like none of our repositories have open issues at the
-          moment! What a great problem to have.
+          Wow, it looks like none of our repositories have open issues or pull
+          requests at the moment! What a great problem to have.
         </div>
 
         <ul>
@@ -73,7 +73,7 @@
             <a href="#" target="_blank" class="no-styles-a" data-tag="repo-link">
               <div class="card interactive">
                 <span class="issues-count pill" data-tag="issues-count">
-                  4 open issues
+                  4 issues/PRs
                 </span>
                 <span class="language outline-badge" data-tag="language">
                   HTML
@@ -81,7 +81,7 @@
                 <h3 class="headline" data-tag="name">
                   Hacker Challenge
                 </h3>
-                <p class="subtitle" data-tag="description">
+                <p class="subtitle description" data-tag="description">
                   Use your web inspector to hack your way through a series of
                   challenges.
                 </p>

--- a/index.html
+++ b/index.html
@@ -60,22 +60,34 @@
       </p>
     </div>
 
-    <div class="repos">
+    <div class="repos" data-tag="repos">
       <div class="container">
         <h2 class="title">Active repositories with open issues</h2>
         <div class="no-repos lead hidden" data-tag="no-repos">
-          Wow, it looks like none of our repositories have open issues at the moment! What a great problem to have.
+          Wow, it looks like none of our repositories have open issues at the
+          moment! What a great problem to have.
         </div>
 
         <ul>
-          <li class="repo" data-tag="example-repo">
-            <a href="#" class="no-styles-a">
+          <li class="repo hidden" data-tag="example-repo">
+            <a href="#" target="_blank" class="no-styles-a" data-tag="repo-link">
               <div class="card interactive">
-                <span class="issues-count pill">4 open issues</span>
-                <span class="lang outline-badge">HTML</span>
-                <h3 class="name headline">Hacker Challenge</h3>
-                <p class="description subtitle">Use your web inspector to hack your way through a series of challenges.</p>
-                <span class="last-push caption">Last push on 02-21-2022</span>
+                <span class="issues-count pill" data-tag="issues-count">
+                  4 open issues
+                </span>
+                <span class="language outline-badge" data-tag="language">
+                  HTML
+                </span>
+                <h3 class="headline" data-tag="name">
+                  Hacker Challenge
+                </h3>
+                <p class="subtitle" data-tag="description">
+                  Use your web inspector to hack your way through a series of
+                  challenges.
+                </p>
+                <span class="caption" data-tag="last-push">
+                  Last push on 02-21-2022
+                </span>
               </div>
             </a>
           </li>

--- a/script.js
+++ b/script.js
@@ -19,10 +19,14 @@ window.addEventListener("DOMContentLoaded", (event) => {
               .href = repo["html_url"];
             repoEl.querySelector("[data-tag='name']")
               .innerText = "hackclub/" + repo["name"];
-            repoEl.querySelector("[data-tag='issues-count']")
-              .innerText = openIssuesCount;
             repoEl.querySelector("[data-tag='description']")
               .innerText = repo["description"];
+
+            // Format issues
+            let formattedText = openIssuesCount == 1 ? " open issue" : " open issues"
+
+            repoEl.querySelector("[data-tag='issues-count']")
+              .innerText = openIssuesCount + formattedText;
 
             // Format date
             let pushedAtDate = new Date(repo["pushed_at"])

--- a/script.js
+++ b/script.js
@@ -19,14 +19,20 @@ window.addEventListener("DOMContentLoaded", (event) => {
               .href = repo["html_url"];
             repoEl.querySelector("[data-tag='name']")
               .innerText = repo["name"];
-            repoEl.querySelector("[data-tag='language']")
-              .innerText = repo["language"];
             repoEl.querySelector("[data-tag='issues-count']")
               .innerText = openIssuesCount;
             repoEl.querySelector("[data-tag='description']")
               .innerText = repo["description"];
             repoEl.querySelector("[data-tag='last-push']")
               .innerText = repo["pushed_at"];
+
+            // Languages can occasionally be null
+            languageEl = repoEl.querySelector("[data-tag='language']");
+            if (repo["language"]) {
+              languageEl.innerText = repo["language"];
+            } else {
+              languageEl.classList.add("hidden");
+            }
 
             reposListEl.appendChild(repoEl);
           }

--- a/script.js
+++ b/script.js
@@ -18,22 +18,37 @@ window.addEventListener("DOMContentLoaded", (event) => {
             repoEl.querySelector("[data-tag='repo-link']")
               .href = repo["html_url"];
             repoEl.querySelector("[data-tag='name']")
-              .innerText = "hackclub/" + repo["name"];
+              .innerText = repo["name"];
             repoEl.querySelector("[data-tag='description']")
               .innerText = repo["description"];
 
             // Format issues
-            let formattedText = openIssuesCount == 1 ? " open issue" : " open issues"
+            let formattedText = openIssuesCount == 1
+              ? " issue or PR"
+              : " issues and PRs"
 
             repoEl.querySelector("[data-tag='issues-count']")
               .innerText = openIssuesCount + formattedText;
 
             // Format date
-            let pushedAtDate = new Date(repo["pushed_at"])
-              .toLocaleString();
+            let currentDate = new Date();
+            let pushedAtDate = new Date(repo["pushed_at"]);
+
+            let diffInMS = (currentDate.getTime() - pushedAtDate.getTime())
+            let diffInDays =  Math.floor(diffInMS / (1000 * 3600 * 24));
+
+            let dateText;
+
+            if (diffInDays < 1) {
+              dateText = "today";
+            } else if (diffInDays == 1) {
+              dateText = diffInDays + " day ago"
+            } else if (diffInDays >= 2) {
+              dateText = diffInDays + " days ago"
+            }
 
             repoEl.querySelector("[data-tag='last-push']")
-              .innerText = "Last pushed at " + pushedAtDate;
+              .innerText = "Last updated " + dateText;
 
             // Languages can occasionally be null
             languageEl = repoEl.querySelector("[data-tag='language']");

--- a/script.js
+++ b/script.js
@@ -18,13 +18,18 @@ window.addEventListener("DOMContentLoaded", (event) => {
             repoEl.querySelector("[data-tag='repo-link']")
               .href = repo["html_url"];
             repoEl.querySelector("[data-tag='name']")
-              .innerText = repo["name"];
+              .innerText = "hackclub/" + repo["name"];
             repoEl.querySelector("[data-tag='issues-count']")
               .innerText = openIssuesCount;
             repoEl.querySelector("[data-tag='description']")
               .innerText = repo["description"];
+
+            // Format date
+            let pushedAtDate = new Date(repo["pushed_at"])
+              .toLocaleString();
+
             repoEl.querySelector("[data-tag='last-push']")
-              .innerText = repo["pushed_at"];
+              .innerText = "Last pushed at " + pushedAtDate;
 
             // Languages can occasionally be null
             languageEl = repoEl.querySelector("[data-tag='language']");

--- a/script.js
+++ b/script.js
@@ -5,22 +5,43 @@ window.addEventListener("DOMContentLoaded", (event) => {
     .then(function(response) {
       return response.json();
     }).then(function(repos) {
-      repos.forEach((repo) => {
-        let reposListEl = document.querySelector(".repos");
-        let repoEl = document.querySelector(".example-repo");
+      if (repos.length > 0) {
+        repos.forEach((repo) => {
+          let openIssuesCount = repo["open_issues_count"];
+          if (openIssuesCount > 0) {
+            let reposListEl = document.querySelector("[data-tag='repos'] ul");
+            let exampleEl = document.querySelector("[data-tag='example-repo']");
 
-        if (repo['has_issues']) {
-          console.log(repo['name']);
-          console.log(repo['open_issues_count']);
-          console.log(repo['html_url']);
-          console.log(repo['language']);
-          console.log(repo['description']);
-          console.log("Last pushed at: " + repo['pushed_at']);
-          console.log('---------------------------');
-        };
-      })
-    }).catch(function() {
-      console.log("Fetching " + url + "failed");
+            let repoEl = exampleEl.cloneNode(true);
+            repoEl.classList.remove("hidden");
+
+            repoEl.querySelector("[data-tag='repo-link']")
+              .href = repo["html_url"];
+            repoEl.querySelector("[data-tag='name']")
+              .innerText = repo["name"];
+            repoEl.querySelector("[data-tag='language']")
+              .innerText = repo["language"];
+            repoEl.querySelector("[data-tag='issues-count']")
+              .innerText = openIssuesCount;
+            repoEl.querySelector("[data-tag='description']")
+              .innerText = repo["description"];
+            repoEl.querySelector("[data-tag='last-push']")
+              .innerText = repo["pushed_at"];
+
+            reposListEl.appendChild(repoEl);
+          }
+        })
+      } else {
+        showEmptyMessage();
+      }
+    }).catch(function(err) {
+      console.log("Fetching " + url + " failed");
+      console.log("Error: " + err);
     }
   );
+
+  function showEmptyMessage() {
+    let noReposEl = document.querySelector("[data-tag='no-repos']");
+    noReposEl.classList.remove("hidden");
+  }
 });

--- a/style.css
+++ b/style.css
@@ -75,8 +75,8 @@ ul {
   margin-bottom: var(--spacing-4);
 }
 
-.repo .card {
-  min-height: 220px;
+.repo .description {
+  min-height: 50px;
 }
 
 .issues-count, .language {

--- a/style.css
+++ b/style.css
@@ -65,8 +65,18 @@ ul {
   margin-bottom: var(--spacing-5);
 }
 
+.repos ul {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--spacing-3);
+}
+
 .repo {
   margin-bottom: var(--spacing-4);
+}
+
+.repo .card {
+  min-height: 220px;
 }
 
 .issues-count, .language {

--- a/style.css
+++ b/style.css
@@ -69,7 +69,7 @@ ul {
   margin-bottom: var(--spacing-4);
 }
 
-.issues-count, .lang {
+.issues-count, .language {
   float: right;
   margin-right: var(--spacing-1);
   top: 0;


### PR DESCRIPTION
Make repos list use GitHub API.

Since it's a static site, we are using the unauthenticated API to grab open repos.

Fixes https://github.com/hackclub/contribute/issues/4 and https://github.com/hackclub/contribute/issues/6.

<img width="1187" alt="Screen Shot 2022-03-14 at 1 45 11 PM" src="https://user-images.githubusercontent.com/621904/158230680-de7cae93-086a-4968-80a7-91fa9d9efeb0.png">

