### PR TITLE
Link to VSC as text editor

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,7 +121,7 @@
               >git</a
             >
             set up on your machine, and a
-            <a href="https://desktop.github.com/" target="_blank"
+            <a href="https://code.visualstudio.com/" target="_blank"
               >text editor</a
             >
             for editing the code.


### PR DESCRIPTION
I don't think GitHub Desktop is a text editor. 

This PR changes the link to VS Code instead of GitHub Desktop.